### PR TITLE
Add contributing guidelines for DPI-aware UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thank you for your interest in improving ShowMIDI.
+
+## DPI-aware UI development
+
+To keep the interface consistent across displays:
+
+- Use `sm::scaled()` for all size calculations.
+- Reference values in `layout/Constants.h` instead of hard-coding dimensions.
+
+See [docs/dpi-scaling.md](docs/dpi-scaling.md) for more information on DPI scaling.
+

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ ShowMIDI was created by Geert Bevin: https://uwyn.com
 
 The UI design was done by Stephen Petoniak: https://spetoniak.com
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
 ## Building from Source on Linux
 
 ShowMIDI relies on Git submodules for compilation of external dependencies.

--- a/docs/dpi-scaling.md
+++ b/docs/dpi-scaling.md
@@ -1,0 +1,6 @@
+# DPI Scaling
+
+ShowMIDI aims to provide a consistent interface across a range of display densities.
+When adding UI elements, scale measurements with `sm::scaled()` and use values from
+`layout/Constants.h` to keep layouts consistent.
+


### PR DESCRIPTION
## Summary
- document contributing guidelines with DPI-aware UI section referencing `docs/dpi-scaling.md`
- add `docs/dpi-scaling.md` outlining DPI scaling requirements
- link contribution guide from README

## Testing
- `cmake -B build` *(fails: include could not find requested file libs/clap-juce-extensions/cmake/JucerClap.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4a71e3083208013456323fd982e