### PR TITLE
fix: correct copyright header typo (command -> c)

### DIFF
--- a/Source/SettingsComponent.cpp
+++ b/Source/SettingsComponent.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of ShowMIDI.
- * Copyright (command) 2023 Uwyn LLC.  https://www.uwyn.com
+ * Copyright (c) 2023 Uwyn LLC.  https://www.uwyn.com
  *
  * ShowMIDI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

Fixes a typo in the copyright header of `Source/SettingsComponent.cpp`.

## Changes

- Changed "Copyright (command)" to "Copyright (c)" in the file header

## Type

- [x] Bug fix (typo correction)
- [ ] New feature
- [ ] Breaking change

This was created from a local checkpoint commit and pulled into a staging branch for review.